### PR TITLE
Use the first argument as the file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 const { Toolkit } = require('actions-toolkit')
+const path = require('path')
 const tools = new Toolkit()
 
 // TODO: Detect if script exists and fails gracefully if it doesn't
-const scriptPath = `/.github/actions/${tools.context.event}.js`
-require(tools.workspace + scriptPath)(tools)
+const scriptPath = tools.arguments._[0] || `/.github/actions/${tools.context.event}.js`
+// Remove the file from the list of arguments
+if (tools.arguments._[0]) tools.arguments._.shift()
+require(path.join(tools.workspace, scriptPath))(tools)


### PR DESCRIPTION
This PR enables a workflow to specify a file name:

```workflow
action "Some action" {
  uses = "mcolyer/actions-toolkit-action@master"
  args = ".github/actions/some-script.js"
}
```

In doing this, I've made it remove the filename from the list of unnamed arguments in `tools.arguments` (if its present).

I've also made a semi-related change to resolve the path to the file using Node's `path` module, for more consistent cross-OS pathing.

Closes #2 